### PR TITLE
Arguments passed to execute() must be in a sequence

### DIFF
--- a/src/oasis/lib/DB.py
+++ b/src/oasis/lib/DB.py
@@ -971,7 +971,7 @@ def copy_qt(qt_id):
     res = run_sql("SELECT owner, title, description, marker, scoremax, status "
                   "FROM qtemplates "
                   "WHERE qtemplate = %s",
-                  qt_id)
+                  (qt_id,))
     if not res:
         raise KeyError("QTemplate %d not found" % qt_id)
     orig = res[0]


### PR DESCRIPTION
The copy_qt function wasn't passing the qt_id in a sequence, causing the following exception. This pull request fixes the issue.

```
Exception on /cadmin/1136/topic_save/156 [POST] Traceback (most recent call last):
File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1504, in wsgi_app
    response = self.full_dispatch_request()
File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1264, in full_dispatch_request
    rv = self.handle_user_exception(e)
File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1262, in full_dispatch_request
    rv = self.dispatch_request()
File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1248, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
File "/opt/oasisqe/3.9/src/oasis/__init__.py", line 197, in call_fn
    return func(*args, **kwargs)
File "/opt/oasisqe/3.9/src/oasis/views_cadmin.py", line 859, in cadmin_topic_save
    result = Setup.doTopicPageCommands(request, topic_id, user_id)
File "/opt/oasisqe/3.9/src/oasis/lib/Setup.py", line 84, in doTopicPageCommands
    newid = DB.copy_qt_all(qtid)
File "/opt/oasisqe/3.9/src/oasis/lib/DB.py", line 941, in copy_qt_all
    newid = copy_qt(qt_id)
File "/opt/oasisqe/3.9/src/oasis/lib/DB.py", line 974, in copy_qt
    qt_id)
File "/opt/oasisqe/3.9/src/oasis/lib/DB.py", line 44, in run_sql
    res = conn.run_sql(sql, params, quiet=quiet)
File "/opt/oasisqe/3.9/src/oasis/lib/Pool.py", line 51, in run_sql
    rec = cur.execute(sql, params)
TypeError: 'int' object does not support indexing
```
