### PR TITLE
Modify create_qt() to assert that scoremax can be None

### DIFF
--- a/src/oasis/lib/DB.py
+++ b/src/oasis/lib/DB.py
@@ -1006,7 +1006,7 @@ def create_qt(owner, title, desc, marker, scoremax, status):
     assert isinstance(title, str) or isinstance(title, unicode)
     assert isinstance(desc, str) or isinstance(desc, unicode)
     assert isinstance(marker, int)
-    assert isinstance(scoremax, float)
+    assert isinstance(scoremax, float) or scoremax is None
     assert isinstance(status, int)
     conn = dbpool.begin()
     conn.run_sql("INSERT INTO qtemplates (owner, title, description, marker, scoremax, status, version) "


### PR DESCRIPTION
This patch allows scoremax to be a None type, as qtemplates in the DB with a scoremax of NULL cause an AssertionError when they hit this assert. This fixes copying of questions to a new topic. 
