### PR TITLE
Update templates to use bundled jQuery

### DIFF
--- a/src/templates/landing_page.html
+++ b/src/templates/landing_page.html
@@ -10,7 +10,7 @@
     <link href="{{ cf.static }}css/datepicker.css" rel="stylesheet"
           media="screen">
 
-    <script src="{{ cf.static }}js/jquery-1.8.3.min.js"></script>
+    <script src="{{ cf.static }}js/jquery-1.10.1.min.js"></script>
     <script src="{{ cf.static }}js/bootstrap.min.js"></script>
     <script src="{{ cf.static }}js/bootstrap-datepicker.js"></script>
     <style>

--- a/src/templates/login_forgot_pass.html
+++ b/src/templates/login_forgot_pass.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="{{ cf.static }}css/bootstrap.min.css" rel="stylesheet"
         media="screen">
-  <script src="{{ cf.static }}js/jquery-1.8.3.min.js"></script>
+  <script src="{{ cf.static }}js/jquery-1.10.1.min.js"></script>
   <script src="{{ cf.static }}js/bootstrap.min.js"></script>
 
 </head>

--- a/src/templates/login_forgot_pass_submit.html
+++ b/src/templates/login_forgot_pass_submit.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="{{ cf.static }}css/bootstrap.min.css" rel="stylesheet"
         media="screen">
-  <script src="{{ cf.static }}js/jquery-1.8.3.min.js"></script>
+  <script src="{{ cf.static }}js/jquery-1.10.1.min.js"></script>
   <script src="{{ cf.static }}js/bootstrap.min.js"></script>
 
 </head>

--- a/src/templates/login_signup.html
+++ b/src/templates/login_signup.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="{{ cf.static }}css/bootstrap.min.css" rel="stylesheet"
         media="screen">
-  <script src="{{ cf.static }}js/jquery-1.8.3.min.js"></script>
+  <script src="{{ cf.static }}js/jquery-1.10.1.min.js"></script>
   <script src="{{ cf.static }}js/bootstrap.min.js"></script>
 
 </head>

--- a/src/templates/login_signup_confirmed.html
+++ b/src/templates/login_signup_confirmed.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="{{ cf.static }}css/bootstrap.min.css" rel="stylesheet"
         media="screen">
-  <script src="{{ cf.static }}js/jquery-1.8.3.min.js"></script>
+  <script src="{{ cf.static }}js/jquery-1.10.1.min.js"></script>
   <script src="{{ cf.static }}js/bootstrap.min.js"></script>
 
 </head>

--- a/src/templates/login_signup_submit.html
+++ b/src/templates/login_signup_submit.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="{{ cf.static }}css/bootstrap.min.css" rel="stylesheet"
         media="screen">
-  <script src="{{ cf.static }}js/jquery-1.8.3.min.js"></script>
+  <script src="{{ cf.static }}js/jquery-1.10.1.min.js"></script>
   <script src="{{ cf.static }}js/bootstrap.min.js"></script>
 
 </head>

--- a/src/templates/login_webauth_error.html
+++ b/src/templates/login_webauth_error.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="{{ cf.static }}css/bootstrap.min.css" rel="stylesheet"
         media="screen">
-  <script src="{{ cf.static }}js/jquery-1.8.3.min.js"></script>
+  <script src="{{ cf.static }}js/jquery-1.10.1.min.js"></script>
   <script src="{{ cf.static }}js/bootstrap.min.js"></script>
 
 </head>


### PR DESCRIPTION
jQuery 1.10.1 is bundled but some of the templates point to jQuery 1.8.3, which does not exist in the static dir. Update the templates to use jQuery 1.10.1